### PR TITLE
Update bootstrap_cli.php

### DIFF
--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -3,6 +3,6 @@ use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Josegonzalez\Version\Event\VersionListener;
 
-EventManager::instance()->attach(function (Event $event) {
+EventManager::instance()->on('Bake.beforeRender', function (Event $event) {
     (new VersionListener($event))->execute();
-}, 'Bake.beforeRender');
+});


### PR DESCRIPTION
Changed from [deprecated method attach](http://api.cakephp.org/3.0/class-Cake.Event.EventManager.html#_attach)