### PR TITLE
Enhance table/associations handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,4 @@ There are two behavior configurations that may be used:
 
 - `versionTable`: (Default: `version`) The name of the table to be used to store versioned data. It may be useful to use a different table when versioning multiple types of entities.
 - `versionField`: (Default: `version_id`) The name of the field in the versioned table that will store the current version. If missing, the plugin will continue to work as normal.
+- `referenceName`: (Default: db table name) Discriminator used to identify records in the version table.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ bin/cake bake migration add_version_id_to_posts version_id:integer
 
 ### Configuration
 
-There are two behavior configurations that may be used:
+There are three behavior configurations that may be used:
 
 - `versionTable`: (Default: `version`) The name of the table to be used to store versioned data. It may be useful to use a different table when versioning multiple types of entities.
 - `versionField`: (Default: `version_id`) The name of the field in the versioned table that will store the current version. If missing, the plugin will continue to work as normal.

--- a/src/Event/EventListener.php
+++ b/src/Event/EventListener.php
@@ -49,6 +49,7 @@ abstract class EventListener implements EventListenerInterface
     public function isType($type)
     {
         $template = sprintf('Bake/%s.ctp', $type);
+
         return strpos($this->event->data[0], $template) !== false;
     }
 

--- a/src/Event/VersionListener.php
+++ b/src/Event/VersionListener.php
@@ -113,6 +113,7 @@ class VersionListener extends EventListener
 
             unset($belongsTo[$i]);
         }
+
         return $belongsTo;
     }
 

--- a/src/Model/Behavior/Version/VersionTrait.php
+++ b/src/Model/Behavior/Version/VersionTrait.php
@@ -54,6 +54,7 @@ trait VersionTrait
 
         $entity = $entities->first();
         $this->set('_versions', $entity->get('_versions'));
+
         return $this->get('_versions');
     }
 }

--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -246,12 +246,13 @@ class VersionBehavior extends Behavior
     public function groupVersions($results)
     {
         return $results->map(function ($row) {
+            $versionField = $this->_config['versionField'];
             $versions = (array)$row->get('__version');
             $grouped = new Collection($versions);
 
             $result = [];
             foreach ($grouped->combine('field', 'content', 'version_id') as $versionId => $keys) {
-                $version = $this->_table->newEntity($keys + ['version_id' => $versionId], [
+                $version = $this->_table->newEntity($keys + [$versionField => $versionId], [
                     'markNew' => false,
                     'useSetters' => false,
                     'markClean' => true

--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -185,6 +185,7 @@ class VersionBehavior extends Behavior
             $versionId = Hash::get($preexistent, '0.version_id', 0) + 1;
         }
         $created = new DateTime();
+        $new = [];
         foreach ($values as $field => $content) {
             if (in_array($field, $primaryKey) || $field == $versionField) {
                 continue;

--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -251,6 +251,7 @@ class VersionBehavior extends Behavior
     {
         $association = $this->versionAssociation();
         $name = $association->name();
+
         return $query
             ->contain([$name => function ($q) use ($name, $options, $query) {
                 if (!empty($options['primaryKey'])) {
@@ -266,6 +267,7 @@ class VersionBehavior extends Behavior
                     $q->where(["$name.version_id IN" => $options['versionId']]);
                 }
                 $q->where(["$name.field IN" => $this->_fields()]);
+
                 return $q;
             }])
             ->formatResults([$this, 'groupVersions'], $query::PREPEND);
@@ -281,6 +283,7 @@ class VersionBehavior extends Behavior
     public function groupVersions($results)
     {
         $property = $this->versionAssociation()->property();
+
         return $results->map(function ($row) use ($property) {
             $versionField = $this->_config['versionField'];
             $versions = (array)$row->get($property);
@@ -301,6 +304,7 @@ class VersionBehavior extends Behavior
             $row->set('_versions', $result, $options);
             unset($row[$property]);
             $row->clean();
+
             return $row;
         });
     }
@@ -348,6 +352,7 @@ class VersionBehavior extends Behavior
         if ($field) {
             $field = Inflector::camelize($field);
         }
+
         return $alias . $field . 'Version';
     }
 

--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -287,7 +287,8 @@ class VersionBehavior extends Behavior
 
             $result = [];
             foreach ($grouped->combine('field', 'content', 'version_id') as $versionId => $keys) {
-                $version = $this->_table->newEntity($keys + [$versionField => $versionId], [
+                $entityClass = $this->_table->entityClass();
+                $version = new $entityClass($keys + [$versionField => $versionId], [
                     'markNew' => false,
                     'useSetters' => false,
                     'markClean' => true

--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -208,7 +208,7 @@ class VersionBehavior extends Behavior
             ]);
         }
 
-        $entity->set('__version', $new);
+        $entity->set($association->property(), $new);
         if (!empty($versionField) && in_array($versionField, $this->_table->schema()->columns())) {
             $entity->set($this->_config['versionField'], $versionId);
         }
@@ -223,7 +223,8 @@ class VersionBehavior extends Behavior
      */
     public function afterSave(Event $event, Entity $entity)
     {
-        $entity->unsetProperty('__version');
+        $property = $this->versionAssociation()->property();
+        $entity->unsetProperty($property);
     }
 
     /**
@@ -275,9 +276,10 @@ class VersionBehavior extends Behavior
      */
     public function groupVersions($results)
     {
-        return $results->map(function ($row) {
+        $property = $this->versionAssociation()->property();
+        return $results->map(function ($row) use ($property) {
             $versionField = $this->_config['versionField'];
-            $versions = (array)$row->get('__version');
+            $versions = (array)$row->get($property);
             $grouped = new Collection($versions);
 
             $result = [];
@@ -292,7 +294,7 @@ class VersionBehavior extends Behavior
 
             $options = ['setter' => false, 'guard' => false];
             $row->set('_versions', $result, $options);
-            unset($row['__version']);
+            unset($row[$property]);
             $row->clean();
             return $row;
         });

--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -18,13 +18,13 @@ use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
-use Cake\I18n\Time;
 use Cake\ORM\Behavior;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
+use DateTime;
 
 /**
  * This behavior provides a way to version dynamic data by keeping versions
@@ -152,7 +152,7 @@ class VersionBehavior extends Behavior
 
         $versionId = Hash::get($preexistent, '0.version_id', 0) + 1;
 
-        $created = new Time();
+        $created = new DateTime();
         foreach ($values as $field => $content) {
             if (in_array($field, $primaryKey) || $field == $versionField) {
                 continue;

--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -24,6 +24,7 @@ use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
 use DateTime;
 
 /**
@@ -90,7 +91,7 @@ class VersionBehavior extends Behavior
         $alias = $this->_table->alias();
 
         foreach ($this->_fields() as $field) {
-            $name = $alias . '_' . $field . '_version';
+            $name = $this->_associationName($field);
 
             $this->_table->hasOne($name, [
                 'className' => $table,
@@ -104,7 +105,7 @@ class VersionBehavior extends Behavior
             ]);
         }
 
-        $name = $this->_associationName($table);
+        $name = $this->_associationName();
 
         $this->_table->hasMany($name, [
             'className' => $table,
@@ -302,15 +303,15 @@ class VersionBehavior extends Behavior
     /**
      * Returns default version association name.
      *
-     * @param string $table Table name.
+     * @param string $field Field name.
      * @return string
      */
-    protected function _associationName($table = null)
+    protected function _associationName($field = null)
     {
-        if ($table === null) {
-            $table = $this->_config['versionTable'];
+        $alias = Inflector::singularize($this->_table->alias());
+        if ($field) {
+            $field = Inflector::camelize($field);
         }
-        list(, $name) = pluginSplit($table);
-        return $name;
+        return $alias . $field . 'Version';
     }
 }

--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -168,19 +168,22 @@ class VersionBehavior extends Behavior
         $foreignKey = $this->_extractForeignKey($entity);
         $versionField = $this->_config['versionField'];
 
-        $table = TableRegistry::get($this->_config['versionTable']);
-        $preexistent = $table->find()
-            ->select(['version_id'])
-            ->where([
-                'model' => $model
-            ] + $foreignKey)
-            ->order(['id desc'])
-            ->limit(1)
-            ->hydrate(false)
-            ->toArray();
+        if (isset($options['versionId'])) {
+            $versionId = $options['versionId'];
+        } else {
+            $table = TableRegistry::get($this->_config['versionTable']);
+            $preexistent = $table->find()
+                ->select(['version_id'])
+                ->where([
+                    'model' => $model
+                ] + $foreignKey)
+                ->order(['id desc'])
+                ->limit(1)
+                ->hydrate(false)
+                ->toArray();
 
-        $versionId = Hash::get($preexistent, '0.version_id', 0) + 1;
-
+            $versionId = Hash::get($preexistent, '0.version_id', 0) + 1;
+        }
         $created = new DateTime();
         foreach ($values as $field => $content) {
             if (in_array($field, $primaryKey) || $field == $versionField) {

--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -253,7 +253,7 @@ class VersionBehavior extends Behavior
                     $foreignKey = (array)$this->_config['foreignKey'];
                     $aliasedFK = [];
                     foreach ($foreignKey as $field) {
-                        $aliasedFK[] = current($query->aliasField($field)) . ' IN';
+                        $aliasedFK[] = "$name.$field";
                     }
                     $conditions = array_combine($aliasedFK, (array)$options['primaryKey']);
                     $q->where($conditions);


### PR DESCRIPTION
This PR provides several enhancements:
- an ability to set `referenceName` (just like in the core ~Tree~ Translate behavior), table alias isn't always a good discriminator (it fails when a table is loaded several times using different aliases)
- association handling overhaul: the idea behind `versionTable` config was rather unclear (sometimes used as a db table, sometimes as a TableRegistry key and sometimes as an associaciot name); now it's used to describe ORM table used to store versions.
- public accessor for version associations: both "global" versions association and individual "per-field" associations
- versions are hydrated using source table `entityClass` rather than the core `Entity`
