### PR TITLE
Fix additional data coming from right table.

### DIFF
--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -294,11 +294,15 @@ class VersionBehavior extends Behavior
                 $versionData = [
                     $versionField => $versionId
                 ];
+
+                /* @var \Cake\Datasource\EntityInterface $versionRow */
+                $versionRow = $grouped->match(['version_id' => $versionId])->first();
+
                 foreach ($this->_config['additionalVersionFields'] as $mappedField => $field) {
                     if (!is_string($mappedField)) {
                         $mappedField = 'version_' . $field;
                     }
-                    $versionData[$mappedField] = $row->get($field);
+                    $versionData[$mappedField] = $versionRow->get($field);
                 }
 
                 $version = new $entityClass($keys + $versionData, [

--- a/tests/Fixture/VersionsFixture.php
+++ b/tests/Fixture/VersionsFixture.php
@@ -16,10 +16,6 @@ namespace Josegonzalez\Version\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 
-/**
- * Class TranslateFixture
- *
- */
 class VersionsFixture extends TestFixture
 {
     /**

--- a/tests/Fixture/VersionsWithUserFixture.php
+++ b/tests/Fixture/VersionsWithUserFixture.php
@@ -49,13 +49,13 @@ class VersionsWithUserFixture extends TestFixture
      * @var array
      */
     public $records = [
-        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'author_id', 'content' => 1, 'user_id' => 1],
-        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'title', 'content' => 'First Article', 'user_id' => 1],
-        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'body', 'content' => 'First Article Body', 'user_id' => 1],
-        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'published', 'content' => 'Y', 'user_id' => 1],
-        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'author_id', 'content' => 1, 'custom_field' => 'foo', 'user_id' => 2],
-        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'title', 'content' => 'First Article Version 2', 'custom_field' => 'foo', 'user_id' => 2],
-        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'body', 'content' => 'First Article Body Version 2', 'custom_field' => 'foo', 'user_id' => 2],
-        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'published', 'content' => 'N', 'custom_field' => 'foo', 'user_id' => 2],
+        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'author_id', 'content' => 1, 'user_id' => 2],
+        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'title', 'content' => 'First Article', 'user_id' => 2],
+        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'body', 'content' => 'First Article Body', 'user_id' => 2],
+        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'published', 'content' => 'Y', 'user_id' => 2],
+        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'author_id', 'content' => 1, 'custom_field' => 'foo', 'user_id' => 3],
+        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'title', 'content' => 'First Article Version 2', 'custom_field' => 'foo', 'user_id' => 3],
+        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'body', 'content' => 'First Article Body Version 2', 'custom_field' => 'foo', 'user_id' => 3],
+        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'published', 'content' => 'N', 'custom_field' => 'foo', 'user_id' => 3],
     ];
 }

--- a/tests/Fixture/VersionsWithUserFixture.php
+++ b/tests/Fixture/VersionsWithUserFixture.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Josegonzalez\Version\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class VersionsWithUserFixture extends TestFixture
+{
+    /**
+     * table property
+     *
+     * @var string
+     */
+    public $table = 'versions_with_user';
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'version_id' => ['type' => 'integer'],
+        'user_id' => ['type' => 'integer'],
+        'model' => ['type' => 'string', 'null' => false],
+        'foreign_key' => ['type' => 'integer', 'null' => false],
+        'field' => ['type' => 'string', 'null' => false],
+        'content' => ['type' => 'text'],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'author_id', 'content' => 1, 'user_id' => 1],
+        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'title', 'content' => 'First Article', 'user_id' => 1],
+        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'body', 'content' => 'First Article Body', 'user_id' => 1],
+        ['version_id' => 1, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'published', 'content' => 'Y', 'user_id' => 1],
+        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'author_id', 'content' => 1, 'custom_field' => 'foo', 'user_id' => 2],
+        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'title', 'content' => 'First Article Version 2', 'custom_field' => 'foo', 'user_id' => 2],
+        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'body', 'content' => 'First Article Body Version 2', 'custom_field' => 'foo', 'user_id' => 2],
+        ['version_id' => 2, 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'published', 'content' => 'N', 'custom_field' => 'foo', 'user_id' => 2],
+    ];
+}

--- a/tests/TestCase/Model/Behavior/VersionBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/VersionBehaviorTest.php
@@ -345,7 +345,7 @@ class VersionBehaviorTest extends TestCase
 
         $results = $table->find('versions')->toArray();
 
-        $this->assertSame(1, $results[0]['_versions'][1]['version_user_id']);
-        $this->assertSame(2, $results[0]['_versions'][2]['version_user_id']);
+        $this->assertSame(2, $results[0]['_versions'][1]['version_user_id']);
+        $this->assertSame(3, $results[0]['_versions'][2]['version_user_id']);
     }
 }

--- a/tests/TestCase/Model/Behavior/VersionBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/VersionBehaviorTest.php
@@ -23,6 +23,7 @@ class VersionBehaviorTest extends TestCase
      */
     public $fixtures = [
         'plugin.Josegonzalez\Version.versions',
+        'plugin.Josegonzalez\Version.versions_with_user',
         'plugin.Josegonzalez\Version.articles',
         'plugin.Josegonzalez\Version.articles_tags_versions',
         'plugin.Josegonzalez\Version.articles_tags',
@@ -324,5 +325,27 @@ class VersionBehaviorTest extends TestCase
         $table->save($entity);
         $this->assertEquals(3, $entity->version_id);
         $this->assertEquals(['sort_order' => 3, 'version_id' => 3, 'version_created' => null], $entity->version(3)->toArray());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetAdditionalMetaData()
+    {
+        $table = TableRegistry::get('Articles', [
+            'entityClass' => 'Josegonzalez\Version\Test\TestCase\Model\Behavior\TestEntity'
+        ]);
+        $table->addBehavior('Josegonzalez/Version.Version', [
+            'versionTable' => 'versions_with_user',
+            'additionalVersionFields' => ['created', 'user_id'],
+        ]);
+        $article = $table->find('all')->first();
+
+        $versionTable = TableRegistry::get('Version', ['table' => 'versions_with_user']);
+
+        $results = $table->find('versions')->toArray();
+
+        $this->assertSame(1, $results[0]['_versions'][1]['version_user_id']);
+        $this->assertSame(2, $results[0]['_versions'][2]['version_user_id']);
     }
 }


### PR DESCRIPTION
We must read the created/user_id from the correct table, in this case the versions one.

Now a versions dropdown can actually display the additional meta data:

    <option value="6">6 (3/19/17, 9:30 PM by uid 2)</option>