### PR TITLE
Fix association type for field versions.

### DIFF
--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -117,27 +117,31 @@ class VersionBehavior extends Behavior
         if (!$this->_table->associations()->has($name)) {
             $model = $this->_config['referenceName'];
 
+            $options += [
+                'className' => $this->_config['versionTable'],
+                'foreignKey' => $this->_config['foreignKey'],
+                'strategy' => 'subquery',
+                'dependent' => true
+            ];
+
             if ($field) {
-                $this->_table->hasOne($name, $options + [
-                    'className' => $this->_config['versionTable'],
-                    'foreignKey' => $this->_config['foreignKey'],
-                    'joinType' => 'LEFT',
+                $options += [
                     'conditions' => [
                         $name . '.model' => $model,
                         $name . '.field' => $field,
                     ],
                     'propertyName' => $field . '_version'
-                ]);
+                ];
             } else {
-                $this->_table->hasMany($name, $options + [
-                    'className' => $this->_config['versionTable'],
-                    'foreignKey' => $this->_config['foreignKey'],
-                    'strategy' => 'subquery',
-                    'conditions' => ["$name.model" => $model],
-                    'propertyName' => '__version',
-                    'dependent' => true
-                ]);
+                $options += [
+                    'conditions' => [
+                        $name . '.model' => $model
+                    ],
+                    'propertyName' => '__version'
+                ];
             }
+
+            $this->_table->hasMany($name, $options);
         }
 
         return $this->_table->association($name);

--- a/tests/TestCase/Model/Behavior/VersionBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/VersionBehaviorTest.php
@@ -348,4 +348,25 @@ class VersionBehaviorTest extends TestCase
         $this->assertSame(2, $results[0]['_versions'][1]['version_user_id']);
         $this->assertSame(3, $results[0]['_versions'][2]['version_user_id']);
     }
+
+    /**
+     * @return void
+     */
+    public function testAssociations()
+    {
+        $table = TableRegistry::get('Articles', [
+            'entityClass' => 'Josegonzalez\Version\Test\TestCase\Model\Behavior\TestEntity'
+        ]);
+        $table->addBehavior('Josegonzalez/Version.Version');
+
+        $this->assertTrue($table->associations()->has('articleversion'));
+        $versions = $table->association('articleversion');
+        $this->assertInstanceOf('Cake\Orm\Association\HasMany', $versions);
+        $this->assertEquals('__version', $versions->property());
+
+        $this->assertTrue($table->associations()->has('articlebodyversion'));
+        $bodyVersions = $table->association('articlebodyversion');
+        $this->assertInstanceOf('Cake\Orm\Association\HasMany', $bodyVersions);
+        $this->assertEquals('body_version', $bodyVersions->property());
+    }
 }


### PR DESCRIPTION
Both association types must be `HasMany`. It's probably a copy-paste error from translate behavior where a field could only have one value in `i18n` table :)

If it's ok please merge it ASAP as I really need that fix :)