### PR TITLE
Expose preexistent logic in public function getVersionId

### DIFF
--- a/tests/TestCase/Model/Behavior/VersionBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/VersionBehaviorTest.php
@@ -369,4 +369,25 @@ class VersionBehaviorTest extends TestCase
         $this->assertInstanceOf('Cake\Orm\Association\HasMany', $bodyVersions);
         $this->assertEquals('body_version', $bodyVersions->property());
     }
+
+    /**
+     * @return void
+     */
+    public function testGetVersionId()
+    {
+        // init test data
+        $table = TableRegistry::get('Articles', [
+            'entityClass' => 'Josegonzalez\Version\Test\TestCase\Model\Behavior\TestEntity',
+        ]);
+        $table->addBehavior('Josegonzalez/Version.Version');
+        $article = $table->find('all')->where(['version_id' => 2])->first();
+        $article->title = 'First Article Version 3';
+        $table->save($article);
+
+        // action in controller receiving outdated data
+        $table->patchEntity($article, ['version_id' => 2]);
+
+        $this->assertEquals(2, $article->version_id);
+        $this->assertEquals(3, $table->getVersionId($article));
+    }
 }


### PR DESCRIPTION
Need external access to this part inside beforeSave.

```php

class ConcurrentListener implements EventListenerInterface
{
    public function implementedEvents()
    {
        return [
            'Model.beforeSave' => 'onModelBeforeChange',
            'Model.beforeDelete' => 'onModelBeforeChange',
        ];
    }

    public function onModelBeforeChange(Event $event, Entity $entity)
    {
        $table = $event->getSubject();
        if ($table->behaviors()->has('Version')) {
            $version_id = $table->getVersionId($entity);
            if ($version_id !== $entity->version_id) {
                $event->stopPropagation();
                $entity->setError('version_id', 'This entity has changed since you get it.');
                return false;
            }
        }
    }
}
```