### PR TITLE
Remove EntityTrait::unsetProperty deprecation

### DIFF
--- a/src/Model/Behavior/VersionBehavior.php
+++ b/src/Model/Behavior/VersionBehavior.php
@@ -233,7 +233,7 @@ class VersionBehavior extends Behavior
     public function afterSave(Event $event, EntityInterface $entity)
     {
         $property = $this->versionAssociation()->getProperty();
-        $entity->unsetProperty($property);
+        $entity->unset($property);
     }
 
     /**


### PR DESCRIPTION
Replace EntityTrait::unset with EntityTrait::unsetProperty

Currently when executing the tests the following Log is written:

Deprecated Error: EntityTrait::unsetProperty() is deprecated. Use unset() instead. - C:\code\xampp\htdocs\CRM_doxx\vendor\josegonzalez\cakephp-version\src\Model\Behavior\VersionBehavior.php, line: 236
 You can disable all deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED`, or add `vendor/josegonzalez/cakephp-version/src/Model/Behavior/VersionBehavior.php` to  `Error.ignoredDeprecationPaths` in your `config/app.php` to mute deprecations from only this file.
In [C:\code\xampp\htdocs\CRM_doxx\vendor\cakephp\cakephp\src\Core\functions.php, line 316]